### PR TITLE
1 benchmarking of mumps solverjl and mumps solver betterjl

### DIFF
--- a/poisson_solver/mumps_solver.jl
+++ b/poisson_solver/mumps_solver.jl
@@ -1,11 +1,13 @@
-using MUMPS, MPI, SparseArrays, LinearAlgebra, PyPlot
-# Solving: -Laplace(u) = 1 in (0,1) × (0,1)
+# Created by: Devansh Tripathi (github.com/Devansh1106)
+# Created at: UTC+05:30 23:23 
+
+# Solving: -Laplace(u) = sin(2.0*π*x) * sin(2.0*π*y)  in (0,1) × (0,1)
 #                     u = 0 on x = 0, ∀ y
-#                     ∂u/∂η = 0 on x = 1, ∀ y  (first trying for all dirichlet condition)
+#                     u = 0 on x = 1, ∀ y
 #                     u = 0 on y = 0, ∀ x
 #                     u = 0 on y = 1, ∀ x
-
-# using Plots.PlotMeasures # for "mm" support in plotting
+# Exact sol: 1.0/(2.0*(2.0*π)^2) * sin(2.0*π*x) * sin(2.0*π*y)
+using MUMPS, MPI, SparseArrays, LinearAlgebra, PyPlot
 
 # ------------- MPI Initialization -----------------
 MPI.Init()
@@ -75,7 +77,6 @@ if (rank !== 0)
 end
 
 @time begin 
-    # ----------------------------- MPI PART -----------------------------
     A = MPI.bcast(A, comm, root = 0)
     rhs = MPI.bcast(rhs, comm, root = 0)
     println("Broadcasting done from rank 0.")

--- a/poisson_solver/mumps_solver.jl
+++ b/poisson_solver/mumps_solver.jl
@@ -1,19 +1,15 @@
-using MUMPS, MPI, SparseArrays, LinearAlgebra, Plots
-
+using MUMPS, MPI, SparseArrays, LinearAlgebra, PyPlot
 # Solving: -Laplace(u) = 1 in (0,1) × (0,1)
 #                     u = 0 on x = 0, ∀ y
 #                     ∂u/∂η = 0 on x = 1, ∀ y  (first trying for all dirichlet condition)
 #                     u = 0 on y = 0, ∀ x
 #                     u = 0 on y = 1, ∀ x
 
-using SparseArrays
-using SparseMatricesCSR
-using Printf
-using Plots.PlotMeasures 
+# using Plots.PlotMeasures # for "mm" support in plotting
 
 # ------------- MPI Initialization -----------------
 MPI.Init()
-gr()
+# gr()
 comm = MPI.COMM_WORLD
 rank = MPI.Comm_rank(comm)
 size = MPI.Comm_size(comm)
@@ -41,7 +37,6 @@ if (rank == 0)
     dx, dy = (xmax-xmin)/(nx-1), (ymax-ymin)/(ny-1)
     x = LinRange(xmin, xmax, nx)
     y = LinRange(ymin, ymax, ny)
-    # println(length(x))
     # X, Y = meshgrid(x,y, indexing='ij')
 
     println("Grid size = ", nx, "x", ny)
@@ -56,40 +51,22 @@ if (rank == 0)
     Ix, Iy = I(mx), I(my)
 
     A = -kron(Iy, Dxx) - kron(Dyy, Ix) # fact from numerical analysis (tensor product notation)
-    # display(A[1:6,1:6])
-    A_rowmajor = SparseMatrixCSR(A)         # to make it same as Praveen sir's code (row major)
-    # irn, jcn, a = findnz(A_rowmajor)
-    # println(a)
-    # println(irn[1:5])
-    # println(jcn[1:5])
-    # println(a[1:5])
-    # X = [xi for yi in y, xi in x]
-    # Y = [yi for yi in y, xi in x]
+    A_rowmajor = sparse(A)         # to make it same as Praveen sir's code (row major)
 
     # rhs vector
-
-    # b = zeros((mx,my))      # loops can be avoided altogether by using X,Y whenever needed
-    # for j in range(2,my)
-    #     for i in range(2,mx)
-    #         b[i,j] = f(x[i],y[j])
-    #     end
-    # end
-
     rhs = zeros(mx*my)
-    for j in 2:my+1
+    @inbounds for j in 2:my+1
         for i in 2:mx+1
             rhs[(j-2)*mx + i-1] = f(x[i],y[j])
         end
     end
     # ----------------------- exact solution -----------------------------
     uexact = zeros((nx,ny))
-    for i in 1:nx
+    @inbounds for i in 1:nx
         for j in 1:nx
             uexact[i,j] = uexact_(x[i],y[j])
         end
     end
-    # uexact = uexact_.(X,Y)
-    # println(size(uexact))
 end
 
 if (rank !== 0)
@@ -97,51 +74,41 @@ if (rank !== 0)
     rhs = zeros(nx-2)
 end
 
-A = MPI.bcast(A, comm, root = 0)
-rhs = MPI.bcast(rhs, comm, root = 0)
-println("Broadcasting done from rank 0.")
+@time begin 
+    # ----------------------------- MPI PART -----------------------------
+    A = MPI.bcast(A, comm, root = 0)
+    rhs = MPI.bcast(rhs, comm, root = 0)
+    println("Broadcasting done from rank 0.")
+    _sol = solve(A, rhs)
+end
 
-# b = f.(X,Y)
-# println(size(b))
-# println(b[1:5])
-
-
-# ----------------------------- MPI PART -----------------------------
-
-# A = sprand(10, 10, 0.2) + I
-# A = [1.0 0.0; 0.0 2.0]
-# rhs = rand(10)
-# rhs = [1, 4]
-_sol = solve(A, rhs)
 if (rank == 0)
     sol = zeros(nx, ny)
     sol[2:nx-1, 2:ny-1] .= reshape(_sol, nx-2, ny-2) # column major ordering (default in julia)
     # --------------- Plots.jl ---------------------------
-    default(size=(600, 500))
-    p1 = contour(x, y, transpose(sol), cmap=:viridis, levels=20, xlabel="x", ylabel="y", title="Solution", linewidths=1.2, right_margin = 10mm)
-    A = abs.(transpose(sol .- uexact))
-    # println("Press Enter to close..."); readline() 
-    default(size=(600, 500))
-    p2 = contourf(x, y, A, cmap=:viridis, colorbar=true,levels=20, xlabel="x", ylabel="y", title="Absolute Error", right_margin = 10mm)
-    # --------------- Plots.jl end -----------------------
-    
-    # ----------------------- PyPlots.jl -----------------------------
-    # figure(figsize=(7,5), constrained_layout=true)
+    # default(size=(600, 500))
+    # p1 = contour(x, y, sol', cmap=:viridis, levels=20, xlabel="x", ylabel="y", title="Solution", linewidths=1.2, right_margin = 10mm)
     # A = abs.(transpose(sol .- uexact))
-    # p2 = contourf(x, y, A; levels=30, cmap="viridis", antialiased=true)
-    # colorbar(p2)                            # Matplotlib will show offset text automatically
-    # p1 = contour(x, y, transpose(sol); levels=20, colors="k", linewidths=0.6)
-    # xlabel("x"); ylabel("y"); title("Absolute Error")
+    # # println(A[50,50])
+    # # println("Press Enter to close..."); readline() 
+    # p2 = contourf(x, y, A, cmap=:viridis, colorbar=true,levels=30, xlabel="x", ylabel="y", title="Absolute Error", right_margin = 10mm)
+    # --------------- Plots.jl end -----------------------
+
+    # ----------------------- PyPlots.jl -----------------------------
+    figure(figsize=(6,5), constrained_layout=true)
+    p1 = contour(x, y, transpose(sol), cmap="viridis", levels=20, linewidths=0.6)
+    savefig("plot1_jl.png", dpi=300)
+    Z = abs.(transpose(sol - uexact))
+    p2 = contourf(x, y, Z, levels=30, cmap="viridis")
+    colorbar(p2)                            # Matplotlib will show offset text automatically
+    xlabel("x"); ylabel("y"); title("Absolute Error")
+    savefig("plot2_jl.png", dpi=300)
     # ----------------------- Pyplot.jl -------------------------------
 
-
-
-    savefig(p1, "plot1.png")
-    savefig(p2, "plot2.png")
-
+    # savefig(p1, "plot1_jl.png")
+    # savefig(p2, "plot2_jl.png")
+    print("Absolute Error: ")
     println(maximum(sol .- uexact))
-    println("Press Enter to close..."); readline()
+    # println("Press Enter to close..."); readline()
 end
-# println(norm(x - A \ rhs) / norm(x))
-# finalize()
 MPI.Finalize()

--- a/poisson_solver/mumps_solver_better.jl
+++ b/poisson_solver/mumps_solver_better.jl
@@ -1,27 +1,27 @@
-using MUMPS, MPI, SparseArrays, LinearAlgebra, Plots
+# Created by: Devansh Tripathi (github.com/Devansh1106)
+# Created at: UTC+05:30 23:23 
 
-# Solving: -Laplace(u) = 1 in (0,1) × (0,1)
+# Solving: -Laplace(u) = sin(2.0*π*x) * sin(2.0*π*y)  in (0,1) × (0,1)
 #                     u = 0 on x = 0, ∀ y
-#                     ∂u/∂η = 0 on x = 1, ∀ y  (first trying for all dirichlet condition)
+#                     u = 0 on x = 1, ∀ y
 #                     u = 0 on y = 0, ∀ x
 #                     u = 0 on y = 1, ∀ x
-
-using SparseArrays
-using SparseMatricesCSR
-using Printf
-using Plots.PlotMeasures 
+# Exact sol: 1.0/(2.0*(2.0*π)^2) * sin(2.0*π*x) * sin(2.0*π*y)
+using MUMPS, MPI, SparseArrays, LinearAlgebra, PyPlot
 
 # ------------- MPI Initialization -----------------
 MPI.Init()
-gr()
+# gr()
 comm = MPI.COMM_WORLD
 rank = MPI.Comm_rank(comm)
 size = MPI.Comm_size(comm)
 
 # Mesh size
-nx = 100
-ny = 100
-mumps = Mumps{Float64}(mumps_symmetric, default_icntl, default_cntl64)
+nx = 200
+ny = 200
+icntl = default_icntl[:]
+icntl[1] = -1; icntl[2] = 0; icntl[3] = 0; icntl[4] = 0; # To supress all the MUMPS error messages
+mumps = Mumps{Float64}(mumps_unsymmetric, icntl, default_cntl64)    #mumps_symmetric can cause blowing up absolute error values if matrix is actually not symmetric
 
 if (rank == 0)
     # rhs
@@ -42,8 +42,6 @@ if (rank == 0)
     dx, dy = (xmax-xmin)/(nx-1), (ymax-ymin)/(ny-1)
     x = LinRange(xmin, xmax, nx)
     y = LinRange(ymin, ymax, ny)
-    # println(length(x))
-    # X, Y = meshgrid(x,y, indexing='ij')
 
     println("Grid size = ", nx, "x", ny)
     println("dx = ", dx)
@@ -57,101 +55,49 @@ if (rank == 0)
     Ix, Iy = I(mx), I(my)
 
     A = -kron(Iy, Dxx) - kron(Dyy, Ix) # fact from numerical analysis (tensor product notation)
-    # display(A[1:6,1:6])
     A_rowmajor = sparse(A)         # to make it same as Praveen sir's code (row major)
-    display(A_rowmajor)
-    # irn, jcn, a = findnz(A_rowmajor)
-    # println(a)
-    # println(irn[1:5])
-    # println(jcn[1:5])
-    # println(a[1:5])
-    # X = [xi for yi in y, xi in x]
-    # Y = [yi for yi in y, xi in x]
 
-    # rhs vector
-
-    # b = zeros((mx,my))      # loops can be avoided altogether by using X,Y whenever needed
-    # for j in range(2,my)
-    #     for i in range(2,mx)
-    #         b[i,j] = f(x[i],y[j])
-    #     end
-    # end
-
+    # rhs
     rhs = zeros(mx*my)
-    for j in 2:my+1
+    @inbounds for j in 2:my+1
         for i in 2:mx+1
             rhs[(j-2)*mx + i-1] = f(x[i],y[j])
         end
     end
-    # ----------------------- exact solution -----------------------------
+    # exact solution
     uexact = zeros((nx,ny))
-    for i in 1:nx
+    @inbounds for i in 1:nx
         for j in 1:nx
             uexact[i,j] = uexact_(x[i],y[j])
         end
     end
-    # uexact = uexact_.(X,Y)
-    # println(size(uexact))
     associate_matrix!(mumps, A_rowmajor)
     associate_rhs!(mumps, rhs)
 end
-# print(mumps.par)
-# if (rank !== 0)
-#     A = zeros(nx-2, ny-2)
-#     rhs = zeros(nx-2)
-# end
 
-# A = MPI.bcast(A, comm, root = 0)
-# rhs = MPI.bcast(rhs, comm, root = 0)
-# println("Broadcasting done from rank 0.")
-
-# b = f.(X,Y)
-# println(size(b))
-# println(b[1:5])
-
-
-# ----------------------------- MPI PART -----------------------------
-
-# A = sprand(10, 10, 0.2) + I
-# A = [1.0 0.0; 0.0 2.0]
-# rhs = rand(10)
-# rhs = [1, 4]
-
-factorize!(mumps)
-solve!(mumps)
+# main solver part that call MUMPS internally
+@time begin
+    factorize!(mumps)
+    solve!(mumps)
+end
 MPI.Barrier(comm)
+
 if (rank == 0)
     sol = zeros(nx, ny)
     _sol = get_solution(mumps)
     sol[2:nx-1, 2:ny-1] .= reshape(_sol, nx-2, ny-2) # column major ordering (default in julia)
-    # print(sol[4500:4520])
-    # --------------- Plots.jl ---------------------------
-    default(size=(600, 500))
-    p1 = contour(x, y, transpose(sol), cmap=:viridis, levels=20, xlabel="x", ylabel="y", title="Solution", linewidths=1.2, right_margin = 10mm)
-    Z = abs.(transpose(sol .- uexact))
-    # println("Press Enter to close..."); readline() 
-    default(size=(600, 500))
-    p2 = contourf(x, y, Z, cmap=:viridis, colorbar=true,levels=20, xlabel="x", ylabel="y", title="Absolute Error", right_margin = 10mm)
-    # --------------- Plots.jl end -----------------------
-    
     # ----------------------- PyPlots.jl -----------------------------
-    # figure(figsize=(7,5), constrained_layout=true)
-    # A = abs.(transpose(sol .- uexact))
-    # p2 = contourf(x, y, A; levels=30, cmap="viridis", antialiased=true)
-    # colorbar(p2)                            # Matplotlib will show offset text automatically
-    # p1 = contour(x, y, transpose(sol); levels=20, colors="k", linewidths=0.6)
-    # xlabel("x"); ylabel("y"); title("Absolute Error")
-    # ----------------------- Pyplot.jl -------------------------------
+    figure(figsize=(6,5), constrained_layout=true)
+    p1 = contour(x, y, transpose(sol), cmap="viridis", levels=20, linewidths=0.6)
+    savefig("plot1.png", dpi=300)
+    Z = abs.(transpose(sol - uexact))
+    p2 = contourf(x, y, Z, levels=30, cmap="viridis")
+    colorbar(p2)                            # Matplotlib will show offset text automatically
+    savefig("plot2.png", dpi=300)
+    xlabel("x"); ylabel("y"); title("Absolute Error")
+    # ----------------------- Pyplot.jl end -------------------------------
 
-
-
-    savefig(p1, "plot1.png")
-    savefig(p2, "plot2.png")
-
-    println(maximum(sol .- uexact))
-    println("Press Enter to close..."); readline()
+    println(maximum(abs.(sol - uexact)))
 end
-finalize(mumps)
-# println(norm(x - A \ rhs) / norm(x))
-# finalize()
+finalize(mumps)     # destroy the mumps struct internally
 MPI.Finalize()


### PR DESCRIPTION
Two commits have been added for this issue:  
for `mumps_solver.jl`: b64e7b69c8a9b6d6c0d316170ef4e8ff4f35de4a
for `mumps_solver_better.jl`: 270ed532b53e3d1b55c1fbc59477cf16bdb6ecdb

Currently, I do not see the need for adding complex benchmarking tools from [BenchmarkTools.jl](https://juliaci.github.io/BenchmarkTools.jl/stable/).